### PR TITLE
Parse the attachment section of the Word template

### DIFF
--- a/lib/concept-store.js
+++ b/lib/concept-store.js
@@ -1,6 +1,21 @@
 function getConcepts() {
     return [
         {
+            id: 'REPORTING_TYPE',
+            name: 'Reporting type',
+            section: 'DIMENSION_DESCRIPTOR'
+        },
+        {
+            id: 'SERIES',
+            name: 'SDG series',
+            section: 'DIMENSION_DESCRIPTOR'
+        },
+        {
+            id: 'REF_AREA',
+            name: 'Reference area',
+            section: 'DIMENSION_DESCRIPTOR'
+        },
+        {
             id: 'SDG_INDICATOR_INFO',
             name: '0. Indicator information',
             section: 'SDG_INDICATOR_INFO',

--- a/lib/input/WordTemplateInput.js
+++ b/lib/input/WordTemplateInput.js
@@ -18,6 +18,16 @@ class WordTemplateInput extends BaseInput {
 
             this.cleanHtml($)
 
+            const info = $('body > h1:contains(Metadata Attachment)').first()
+            if (info) {
+                metadata['REPORTING_TYPE'] = this.getOptionValue(info.nextAll(':contains(Reporting type)')
+                    .first().next().text(), 'REPORTING_TYPE')
+                metadata['SERIES'] = this.getOptionValue(info.nextAll(':contains(SDG series)')
+                    .first().next().text(), 'SERIES')
+                metadata['REF_AREA'] = this.getOptionValue(info.nextAll(':contains(Reference area)')
+                    .first().next().text(), 'REF_AREA')
+            }
+
             $('body > table').each((idx, table) => {
                 const section = $(table).find('> tbody > tr > td > h1').first().text()
                 if (section) {
@@ -30,6 +40,11 @@ class WordTemplateInput extends BaseInput {
             })
             return metadata
         })
+    }
+
+    getOptionValue(optionText, selectKey) {
+        // TODO: Add a lookup table to convert these options to values.
+        return optionText
     }
 
     cleanHtml($) {


### PR DESCRIPTION
This is a partial implementation of parsing the "attachment" section of the Word template. Right now it only gets the text value of the drop-down options. We will need to add a lookup table to get the actual key value. (Eg, "G" instead of "Global")