### PR TITLE
Separate descriptors from concepts using Metadata class

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ The above example could be changed to use any of the available inputs/outputs.
 * All inputs have a `read` method, which returns a Promise containing the metadata.
 * All outputs have a `write` method, which returns a Promise (containing nothing).
 
+The metadata which is returned from the inputs, and written by the outputs, is an instance of the Metadata class, which has two methods:
+
+* `getConcepts()`
+* `getDescriptors()`
+
+The "concepts" are the actual metadata about the SDG indicator, while the "descriptors" are metadata about the concepts.
+
 ## Looping
 
 You may want to perform a conversion on muliple source files. For small numbers of files, you can simply loop the code above.
@@ -77,3 +84,21 @@ convert()
 ## Synchronous reading
 
 Some inputs may provide a `readSync` method, for easier use.
+
+## Reading only
+
+Perhaps you would like to use this library to read metadata from a source and then do something other than writing a file. This can be done like so:
+
+```
+const { WordTemplateInput } = require('sdg-metadata-convert')
+const input = new WordTemplateInput()
+const inputFile = '3-8-2.docx'
+
+input.read(inputFile)
+  .then(metadata => doSomething(metadata))
+  .catch(err => console.log(err))
+
+function doSomething(metadata) {
+  // Do something here.
+}
+```

--- a/lib/Metadata.js
+++ b/lib/Metadata.js
@@ -1,0 +1,16 @@
+class Metadata {
+    constructor(concepts, descriptors) {
+        this.concepts = concepts || {}
+        this.descriptors = descriptors || {}
+    }
+
+    getConcepts() {
+        return this.concepts
+    }
+
+    getDescriptors() {
+        return this.descriptors
+    }
+}
+
+module.exports = Metadata

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,8 +5,11 @@ const GettextInput = require('./input/GettextInput')
 const GettextOutput = require('./output/GettextOutput')
 const HtmlOutput = require('./output/HtmlOutput')
 const PdfOutput = require('./output/PdfOutput')
-// Store
-const conceptStore = require('./concept-store')
+// Stores
+const conceptStore = require('./store/concept-store')
+const descriptorStore = require('./store/descriptor-store')
+// Utility classes
+const Metadata = require('./Metadata')
 
 module.exports = {
     WordTemplateInput,
@@ -15,4 +18,6 @@ module.exports = {
     HtmlOutput,
     PdfOutput,
     conceptStore,
+    descriptorStore,
+    Metadata,
 }

--- a/lib/input/GettextInput.js
+++ b/lib/input/GettextInput.js
@@ -1,6 +1,9 @@
 const BaseInput = require('./BaseInput')
 const fs = require('fs')
 const gettextParser = require('gettext-parser')
+const conceptStore = require('../store/concept-store')
+const descriptorStore = require('../store/descriptor-store')
+const Metadata = require('../Metadata')
 
 /**
  * Options:
@@ -21,17 +24,24 @@ class GettextInput extends BaseInput {
     }
 
     parse(data) {
-        const metadata = {}
+        const concepts = {}
+        const descriptors = {}
         const parsed = gettextParser.po.parse(data)
         delete parsed.translations['']
 
         for (const id of Object.keys(parsed.translations)) {
             const source = Object.keys(parsed.translations[id])[0]
             const item = parsed.translations[id][source]
-            metadata[id] = (this.options.sourceStrings) ? item.msgid : item.msgstr[0]
+            const value = (this.options.sourceStrings) ? item.msgid : item.msgstr[0]
+            if (conceptStore.isConcept(id)) {
+                concepts[id] = value
+            }
+            if (descriptorStore.isDescriptor(id)) {
+                descriptors[id] = value
+            }
         }
 
-        return metadata
+        return new Metadata(concepts, descriptors)
     }
 }
 

--- a/lib/input/WordTemplateInput.js
+++ b/lib/input/WordTemplateInput.js
@@ -2,7 +2,9 @@ const BaseInput = require('./BaseInput')
 const mammoth = require('mammoth')
 const cheerio = require('cheerio')
 const pretty = require('pretty')
-const conceptStore = require('../concept-store')
+const conceptStore = require('../store/concept-store')
+const descriptorStore = require('../store/descriptor-store')
+const Metadata = require('../Metadata')
 
 class WordTemplateInput extends BaseInput {
 
@@ -12,7 +14,8 @@ class WordTemplateInput extends BaseInput {
             if (this.options.debug) {
                 console.log(result.messages)
             }
-            const metadata = {}
+            const concepts = {}
+            const descriptors = {}
             const html = result.value
             const $ = cheerio.load(html)
 
@@ -20,25 +23,24 @@ class WordTemplateInput extends BaseInput {
 
             const info = $('body > h1:contains(Metadata Attachment)').first()
             if (info) {
-                metadata['REPORTING_TYPE'] = this.getOptionValue(info.nextAll(':contains(Reporting type)')
-                    .first().next().text(), 'REPORTING_TYPE')
-                metadata['SERIES'] = this.getOptionValue(info.nextAll(':contains(SDG series)')
-                    .first().next().text(), 'SERIES')
-                metadata['REF_AREA'] = this.getOptionValue(info.nextAll(':contains(Reference area)')
-                    .first().next().text(), 'REF_AREA')
+                for (const descriptorId of ['REPORTING_TYPE', 'SERIES', 'REF_AREA']) {
+                    const descriptorName = descriptorStore.getDescriptorNameById(descriptorId)
+                    const descriptorText = info.nextAll(':contains(' + descriptorName + ')').first().next().text()
+                    descriptors[descriptorId] = this.getOptionValue(descriptorText, descriptorId)
+                }
             }
 
             $('body > table').each((idx, table) => {
                 const section = $(table).find('> tbody > tr > td > h1').first().text()
                 if (section) {
-                    const concepts = this.parseConcepts(table, $)
-                    for (const [conceptName, conceptValue] of Object.entries(concepts)) {
+                    const conceptsInSection = this.parseConcepts(table, $)
+                    for (const [conceptName, conceptValue] of Object.entries(conceptsInSection)) {
                         const conceptId = conceptStore.getConceptIdByName(conceptName)
-                        metadata[conceptId] = conceptValue
+                        concepts[conceptId] = conceptValue
                     }
                 }
             })
-            return metadata
+            return new Metadata(concepts, descriptors)
         })
     }
 

--- a/lib/output/GettextOutput.js
+++ b/lib/output/GettextOutput.js
@@ -12,8 +12,9 @@ class GettextOutput extends BaseOutput {
 
     write(metadata, outputFile) {
         const units = {}
-        for (const conceptId of Object.keys(metadata)) {
-            units[conceptId] = this.getUnit(metadata[conceptId], conceptId)
+        const concepts = metadata.getConcepts()
+        for (const conceptId of Object.keys(concepts)) {
+            units[conceptId] = this.getUnit(concepts[conceptId], conceptId)
         }
 
         const data = {

--- a/lib/output/HtmlOutput.js
+++ b/lib/output/HtmlOutput.js
@@ -1,6 +1,6 @@
 const BaseOutput = require('./BaseOutput')
 const nunjucks = require('nunjucks')
-const conceptStore = require('../concept-store')
+const conceptStore = require('../store/concept-store')
 const path = require('path')
 const fsp = require('fs').promises;
 
@@ -22,13 +22,14 @@ class HtmlOutput extends BaseOutput {
 
     prepForLayout(metadata) {
         const prepped = {}
-        for (const conceptId of Object.keys(metadata)) {
+        const concepts = metadata.getConcepts()
+        for (const conceptId of Object.keys(concepts)) {
             const name = conceptStore.getConceptNameById(conceptId)
             if (name) {
                 prepped[conceptId] = {
                     id: conceptId,
                     name: name,
-                    value: metadata[conceptId],
+                    value: concepts[conceptId],
                 }
             }
         }

--- a/lib/output/PdfOutput.js
+++ b/lib/output/PdfOutput.js
@@ -6,7 +6,7 @@ class PdfOutput extends HtmlOutput {
 
     write(metadata, outputFile) {
         const html = this.getHtml(metadata)
-        const options = this.getPuppeteerPdfOptions(metadata['META_LAST_UPDATE'])
+        const options = this.getPuppeteerPdfOptions(metadata.getConcepts()['META_LAST_UPDATE'])
         const callback = pdf => fsp.writeFile(outputFile, pdf)
         return this.convertHtmlToPdfPromise(html, callback, options)
     }

--- a/lib/store/concept-store.js
+++ b/lib/store/concept-store.js
@@ -279,6 +279,10 @@ function getConceptIds() {
     return getConcepts().map(concept => concept.id)
 }
 
+function isConcept(findId) {
+    return getConceptIds().includes(findId)
+}
+
 module.exports = {
     getConcepts,
     getConcept,
@@ -287,4 +291,5 @@ module.exports = {
     getSectionIds,
     getConceptIdsBySectionId,
     getConceptIds,
+    isConcept,
 }

--- a/lib/store/descriptor-store.js
+++ b/lib/store/descriptor-store.js
@@ -1,0 +1,81 @@
+function getDescriptors() {
+    return [
+        {
+            id: 'REPORTING_TYPE',
+            name: 'Reporting type',
+            section: 'DIMENSION_DESCRIPTOR'
+        },
+        {
+            id: 'SERIES',
+            name: 'SDG series',
+            section: 'DIMENSION_DESCRIPTOR'
+        },
+        {
+            id: 'REF_AREA',
+            name: 'Reference area',
+            section: 'DIMENSION_DESCRIPTOR'
+        },
+    ]
+}
+
+function getDescriptor(findId) {
+    const descriptor = getDescriptors().find(descriptor => descriptor.id === findId)
+    if (!descriptor) {
+        console.log(`WARNING: Descriptor with id "${findId}" cannot be found in descriptor-store.js.`)
+    }
+    else {
+        return descriptor
+    }
+}
+
+function getDescriptorIdByName(findName) {
+    const descriptor = getDescriptors().find(descriptor => descriptor.name === findName)
+    if (!descriptor) {
+        console.log(`WARNING: Descriptor with name "${findName}" cannot be found in descriptor-store.js.`)
+    }
+    else {
+        return descriptor.id
+    }
+}
+
+function getDescriptorNameById(findId) {
+    const descriptor = getDescriptors().find(descriptor => descriptor.id === findId)
+    if (!descriptor) {
+        console.log(`WARNING: Descriptor with id "${findId}" cannot be found in descriptor-store.js.`)
+    }
+    else {
+        return descriptor.name
+    }
+}
+
+function getSectionIds() {
+    return getDescriptors()
+        .filter(descriptor => descriptor.id === descriptor.section)
+        .map(descriptor => descriptor.id)
+}
+
+function getDescriptorIdsBySectionId(findSection) {
+    return getDescriptors()
+        .filter(descriptor => descriptor.section === findSection)
+        .map(descriptor => descriptor.id)
+}
+
+function getDescriptorIds() {
+    return getDescriptors().map(descriptor => descriptor.id)
+}
+
+function isDescriptor(findId) {
+    return getDescriptorIds().includes(findId)
+}
+
+module.exports = {
+    getDescriptors,
+    getDescriptor,
+    getDescriptorIds,
+    getDescriptorIdByName,
+    getDescriptorNameById,
+    getSectionIds,
+    getDescriptorIdsBySectionId,
+    getDescriptorIds,
+    isDescriptor,
+}


### PR DESCRIPTION
This allows inputs to bring in "descriptors" without getting mixed in with the concepts.