### PR TITLE
Translate concept names in HTML/PDF output

### DIFF
--- a/lib/layout/base.njk
+++ b/lib/layout/base.njk
@@ -43,6 +43,14 @@
                 font-weight: bold;
                 font-style: italic;
             }
+            {% if rightToLeft %}
+            body {
+                direction: rtl;
+            }
+            body .concept-name {
+                direction: ltr;
+            }
+            {% endif %}
         </style>
         <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
         <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>

--- a/lib/layout/base.njk
+++ b/lib/layout/base.njk
@@ -47,9 +47,6 @@
             body {
                 direction: rtl;
             }
-            body .concept-name {
-                direction: ltr;
-            }
             {% endif %}
         </style>
         <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>

--- a/lib/layout/simple.njk
+++ b/lib/layout/simple.njk
@@ -3,7 +3,7 @@
 {% macro renderConcept(concept) %}
   {% if concept.value %}
     <div id="{{ concept.id }}">
-      {% if conceptNames %}<p class="concept-name">{{ concept.name }}</p>{% endif %}
+      {% if conceptNames %}<p class="concept-name">{{ conceptTranslations[concept.id] | default(concept.name, true) }}</p>{% endif %}
       {{ concept.value }}
     </div>
   {% endif %}

--- a/lib/output/BaseOutput.js
+++ b/lib/output/BaseOutput.js
@@ -46,6 +46,15 @@ class BaseOutput {
     getFilenameExtension() {
         throw 'getFilenameExtension() must be implemented.'
     }
+
+    getLanguage(descriptors) {
+        if (descriptors['LANGUAGE']) {
+            return descriptors['LANGUAGE']
+        }
+        else {
+            return this.options.language ? this.options.language : 'en'
+        }
+    }
 }
 
 module.exports = BaseOutput

--- a/lib/output/BaseOutput.js
+++ b/lib/output/BaseOutput.js
@@ -48,12 +48,13 @@ class BaseOutput {
     }
 
     getLanguage(descriptors) {
+        if (this.options.language) {
+            return this.options.language
+        }
         if (descriptors['LANGUAGE']) {
             return descriptors['LANGUAGE']
         }
-        else {
-            return this.options.language ? this.options.language : 'en'
-        }
+        return 'en'
     }
 }
 

--- a/lib/output/HtmlOutput.js
+++ b/lib/output/HtmlOutput.js
@@ -13,8 +13,9 @@ const path = require('path')
  *   Optionally specify a language to affect the HTML text direction.
  * conceptTranslations: object
  *   Only used if conceptNames is true. Provides a object keyed by
- *   concept ID, with alternative names. If a concept ID is missing
- *   from the object, the default (English) concept name will be used.
+ *   language pointing to objects keyed by concept ID, pointing to
+ *   concept names. If a concept ID is missing from the object, the
+ *   default (English) concept name will be used.
  */
 class HtmlOutput extends BaseOutput {
 
@@ -28,10 +29,8 @@ class HtmlOutput extends BaseOutput {
         const layoutData = this.prepForLayout(metadata)
         const descriptors = metadata.getDescriptors()
         const language = this.getLanguage(descriptors)
-        if (this.rightToLeftLanguages().includes(language)) {
-            layoutData['rightToLeft'] = true
-        }
-        layoutData['conceptTranslations'] = this.getConceptTranslations()
+        layoutData['rightToLeft'] = this.isRightToLeftLanguage(language)
+        layoutData['conceptTranslations'] = this.getConceptTranslationsForLanguage(language)
         const layoutFolder = this.options.layoutFolder || path.join(__dirname, '..', 'layout')
         const layout = this.options.layout || 'simple.njk'
         const nunjucksOptions = this.options.nunjucksOptions || { autoescape: false }
@@ -60,12 +59,16 @@ class HtmlOutput extends BaseOutput {
         return 'html'
     }
 
-    rightToLeftLanguages() {
-        return ['ar']
+    isRightToLeftLanguage(language) {
+        const rtl = ['ar']
+        return rtl.includes(language)
     }
 
-    getConceptTranslations() {
-        return this.options.conceptTranslations ? this.options.conceptTranslations : store.getConceptTranslations()
+    getConceptTranslationsForLanguage(language) {
+        if (this.options.conceptTranslations && this.options.conceptTranslations[language]) {
+            return this.options.conceptTranslations[language]
+        }
+        return store.getConceptTranslations()
     }
 }
 

--- a/lib/output/HtmlOutput.js
+++ b/lib/output/HtmlOutput.js
@@ -9,6 +9,8 @@ const path = require('path')
  * conceptNames: boolean
  *   Set this to true to display the concept names above each concept.
  *   Defaults to false.
+ * language: string
+ *   Optionally specify a language to affect the HTML text direction.
  */
 class HtmlOutput extends BaseOutput {
 
@@ -20,6 +22,11 @@ class HtmlOutput extends BaseOutput {
 
     getHtml(metadata) {
         const layoutData = this.prepForLayout(metadata)
+        const descriptors = metadata.getDescriptors()
+        const language = this.getLanguage(descriptors)
+        if (this.rightToLeftLanguages().includes(language)) {
+            layoutData['rightToLeft'] == true
+        }
         const layoutFolder = this.options.layoutFolder || path.join(__dirname, '..', 'layout')
         const layout = this.options.layout || 'simple.njk'
         const nunjucksOptions = this.options.nunjucksOptions || { autoescape: false }
@@ -46,6 +53,10 @@ class HtmlOutput extends BaseOutput {
 
     getFilenameExtension() {
         return 'html'
+    }
+
+    rightToLeftLanguages() {
+        return ['ar']
     }
 }
 

--- a/lib/output/HtmlOutput.js
+++ b/lib/output/HtmlOutput.js
@@ -11,11 +11,21 @@ const path = require('path')
  *   Defaults to false.
  * language: string
  *   Optionally specify a language to affect the HTML text direction.
+ *   This overrides whatever might be in the LANGUAGE descriptor.
  * conceptTranslations: object
- *   Only used if conceptNames is true. Provides a object keyed by
+ *   Only used if conceptNames is true. Provides an object keyed by
  *   language pointing to objects keyed by concept ID, pointing to
  *   concept names. If a concept ID is missing from the object, the
- *   default (English) concept name will be used.
+ *   default (English) concept name will be used. Eg:
+ *
+ *   {
+ *     ru: {
+ *       SDG_INDICATOR_INFO: '0. Информация о показателе'
+ *     },
+ *     es: {
+ *       SDG_INDICATOR_INFO: '0. Información del indicador'
+ *     }
+ *   }
  */
 class HtmlOutput extends BaseOutput {
 

--- a/lib/output/HtmlOutput.js
+++ b/lib/output/HtmlOutput.js
@@ -11,6 +11,10 @@ const path = require('path')
  *   Defaults to false.
  * language: string
  *   Optionally specify a language to affect the HTML text direction.
+ * conceptTranslations: object
+ *   Only used if conceptNames is true. Provides a object keyed by
+ *   concept ID, with alternative names. If a concept ID is missing
+ *   from the object, the default (English) concept name will be used.
  */
 class HtmlOutput extends BaseOutput {
 
@@ -25,8 +29,9 @@ class HtmlOutput extends BaseOutput {
         const descriptors = metadata.getDescriptors()
         const language = this.getLanguage(descriptors)
         if (this.rightToLeftLanguages().includes(language)) {
-            layoutData['rightToLeft'] == true
+            layoutData['rightToLeft'] = true
         }
+        layoutData['conceptTranslations'] = this.getConceptTranslations()
         const layoutFolder = this.options.layoutFolder || path.join(__dirname, '..', 'layout')
         const layout = this.options.layout || 'simple.njk'
         const nunjucksOptions = this.options.nunjucksOptions || { autoescape: false }
@@ -57,6 +62,10 @@ class HtmlOutput extends BaseOutput {
 
     rightToLeftLanguages() {
         return ['ar']
+    }
+
+    getConceptTranslations() {
+        return this.options.conceptTranslations ? this.options.conceptTranslations : store.getConceptTranslations()
     }
 }
 

--- a/lib/output/SdmxOutput.js
+++ b/lib/output/SdmxOutput.js
@@ -140,15 +140,6 @@ class SdmxOutput extends BaseOutput {
         return descriptors['REPORTING_TYPE'] === 'G' ? 'DF_SDG_GLH' : 'DF_SDG_GLC'
     }
 
-    getLanguage(descriptors) {
-        if (descriptors['LANGUAGE']) {
-            return descriptors['LANGUAGE']
-        }
-        else {
-            return this.options.language ? this.options.language : 'en'
-        }
-    }
-
     getFilenameExtension() {
         return 'xml'
     }

--- a/lib/store/concept-store.js
+++ b/lib/store/concept-store.js
@@ -66,6 +66,14 @@ function isConcept(findId) {
     return getConceptIds().includes(findId)
 }
 
+function getConceptTranslations() {
+    const translations = {}
+    for (const concept of getConcepts()) {
+        translations[concept.id] = concept.name
+    }
+    return translations
+}
+
 module.exports = {
     getConcepts,
     getConcept,
@@ -75,4 +83,5 @@ module.exports = {
     getConceptIdsBySectionId,
     getConceptIds,
     isConcept,
+    getConceptTranslations,
 }


### PR DESCRIPTION
This allows the concept names in HTML/PDF output to be translated according to the language. In addition, if the language is Arabic then the HTML/PDF output will be formatted right-to-left.